### PR TITLE
Allow python-build in ELN

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -97,10 +97,8 @@ data:
         - ocaml-ounit*
         # unwanted python deps
         - python3-anyio
-        - python3-build
         - python3-coverage
         - python3-docs
-        - python3-etcd
         - python3-etcd
         - python3-flask
         - python3-furo


### PR DESCRIPTION
Its dependencies have been minimized, and it appears that it will be needed eventually with the pyproject migration:

https://github.com/fedora-eln/eln/issues/278
https://src.fedoraproject.org/rpms/python-build/pull-request/23