### PR TITLE
Drop cockpit-packagekit from ELN

### DIFF
--- a/configs/rhel-program--image-azure.yaml
+++ b/configs/rhel-program--image-azure.yaml
@@ -11,7 +11,6 @@ data:
       - NetworkManager
       - NetworkManager-cloud-setup
       - NetworkManager-tui
-      - PackageKit
       - WALinuxAgent
       - acl
       - amd-gpu-firmware
@@ -33,7 +32,6 @@ data:
       - cloud-utils-growpart
       - cockpit
       - cockpit-bridge
-      - cockpit-packagekit
       - cockpit-storaged
       - cockpit-system
       - cockpit-ws
@@ -49,6 +47,7 @@ data:
       - dbus
       - dnf5
       - dnf5-plugins
+      - dnf5daemon-server
       - dos2unix
       - dosfstools
       - dracut-config-generic
@@ -171,7 +170,6 @@ data:
       - NetworkManager
       - NetworkManager-cloud-setup
       - NetworkManager-tui
-      - PackageKit
       - WALinuxAgent
       - acl
       - amd-gpu-firmware
@@ -193,7 +191,6 @@ data:
       - cloud-utils-growpart
       - cockpit
       - cockpit-bridge
-      - cockpit-packagekit
       - cockpit-storaged
       - cockpit-system
       - cockpit-ws
@@ -209,6 +206,7 @@ data:
       - dbus
       - dnf5
       - dnf5-plugins
+      - dnf5daemon-server
       - dos2unix
       - dosfstools
       - dracut-config-generic

--- a/configs/rhel-sst-cockpit--web-console.yaml
+++ b/configs/rhel-sst-cockpit--web-console.yaml
@@ -10,7 +10,6 @@ data:
     # meta-package for the basic stuff (web server, bridge, core pages)
     - cockpit
     # recommended packages from cockpit metapackage
-    - cockpit-packagekit
     - cockpit-storaged
     - cockpit-doc
     # extensions maintained by Cockpit team


### PR DESCRIPTION
cockpit already supports dnf5daemon, and only recommends cockpit-packagekit in tandem with dnf-4.

This requires https://src.fedoraproject.org/rpms/cockpit/pull-request/394 to fix the runtime dependency.