### PR TITLE
kde: drop kgamma

### DIFF
--- a/configs/eln_extras_kde_plasma.yaml
+++ b/configs/eln_extras_kde_plasma.yaml
@@ -17,7 +17,6 @@ data:
     - kdeplasma-addons
     - kde-settings-plasma
     - kdesu
-    - kgamma
     - kglobalacceld
     - kinfocenter
     - kmenuedit


### PR DESCRIPTION
This was relevant only to an X11 session:

https://forge.fedoraproject.org/kde/tracker/issues/712
https://invent.kde.org/asavolainen/x11-code-removals

/cc @tdawson
