### PR TITLE
OpenSSL: Add fips-provider

### DIFF
--- a/configs/rhel-sst-security-crypto--openssl.yaml
+++ b/configs/rhel-sst-security-crypto--openssl.yaml
@@ -8,6 +8,7 @@ data:
   maintainer: rhel-sst-security-crypto
   packages:
     - openssl
+    - fips-provider-next
   package_placeholders:
     - srpm_name: openssl-fips-provider
       rpms:
@@ -18,11 +19,6 @@ data:
           description: FIPS module for OpenSSL
           dependencies:
             - coreutils
-    - srpm_name: fips-provider-next
-      rpms:
-        - rpm_name: fips-provider-next
-          description: Next FIPS module, before it is validated
-          dependencies: []
   labels:
     - eln
     - c10s


### PR DESCRIPTION
Splits the c10s and ELN configs into separate files, since c10s does not have fips-provider.