### PR TITLE
Drop low-memory-monitor from ELN

### DIFF
--- a/configs/epel-yselkowitz--cinnamon.yaml
+++ b/configs/epel-yselkowitz--cinnamon.yaml
@@ -10,7 +10,6 @@ data:
     - cinnamon-control-center
     - cinnamon-desktop
     - cinnamon-menus
-    - cinnamon-screensaver
     - cinnamon-session
     - cinnamon-settings-daemon
     - cinnamon-translations

--- a/configs/rhel-net-perf--unwanted.yaml
+++ b/configs/rhel-net-perf--unwanted.yaml
@@ -62,8 +62,6 @@ data:
     - libotr
     - libwvstreams
     - mailman
-    - mod_security
-    - mod_security_crs
     - ntp
     - pakchois
     - perl-PerlIO-gzip

--- a/configs/rhel-sst-display-window-management--gnome-desktop-c10s.yaml
+++ b/configs/rhel-sst-display-window-management--gnome-desktop-c10s.yaml
@@ -1,0 +1,10 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: GNOME Desktop Deprecated
+  description: GNOME Desktop core packages in RHEL 10 which will not be in RHEL 11
+  maintainer: rhel-sst-display-window-management
+  packages:
+    - low-memory-monitor
+  labels:
+    - c10s

--- a/configs/rhel-sst-display-window-management--gnome-desktop.yaml
+++ b/configs/rhel-sst-display-window-management--gnome-desktop.yaml
@@ -22,7 +22,6 @@ data:
     - gnome-shell-extension-windowsNavigator
     - gnome-shell-extension-workspace-indicator
     - gnome-remote-desktop
-    - low-memory-monitor
     - lcms2
     - uresourced
   labels:


### PR DESCRIPTION
GMemoryMonitor no longer requires it as of glib 2.86:

https://gitlab.gnome.org/GNOME/glib/-/work_items/2931

/cc @Jiri-Koten 