### PR TITLE
edge: add oci-delta

### DIFF
--- a/configs/rhel-sst-edge--all.yaml
+++ b/configs/rhel-sst-edge--all.yaml
@@ -19,6 +19,7 @@ data:
     - ignition
     - ignition-edge
     - nss-altfiles
+    - oci-delta
     - ostree
     - rpm-ostree
   arch_packages:


### PR DESCRIPTION
Add oci-delta package to the edge workload and include c9s label for RHEL 9 support.