### PR TITLE
add libzpc2 to c10s

### DIFF
--- a/configs/rhel-sst-arch-hw--c10s.yaml
+++ b/configs/rhel-sst-arch-hw--c10s.yaml
@@ -24,6 +24,7 @@ data:
     - alsa-utils
     - speexdsp
     - hwloc
+    - libzpc2-tools
     - pigz
     - s390utils
     - s390utils-se-data
@@ -50,6 +51,7 @@ data:
       - libzfcphbaapi-docs
       - libzpc
       - libzpc-devel
+      - libzpc2-provider
       - openssl-ibmca
       - qclib
       - qclib-devel


### PR DESCRIPTION
This is a transitional package for c10s to allow early migration to the libzpc version 2. ELN have already included libzpc version 2 under the "libzpc" name.