### PR TITLE
Migrate to nodejs26, add osci-internal-test-package

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -141,6 +141,7 @@ data:
         - python3-pytest-freezer
         - python3-pytest-mock
         - python3-pytest-randomly
+        - python3-pytest-socket
         - python3-pytest-subprocess
         - python3-pytest-timeout
         - python3-pytest-trio

--- a/configs/rhel-databases--containers.yaml
+++ b/configs/rhel-databases--containers.yaml
@@ -38,7 +38,7 @@ data:
     - sqlite-devel
     - zlib-ng-compat-devel
     # common dependency of app containers in s2i-base
-    - nodejs24-npm
+    - nodejs26-npm
   labels:
     - eln
     - c10s

--- a/configs/rhel-pt-ruby-nodejs--nodejs24.yaml
+++ b/configs/rhel-pt-ruby-nodejs--nodejs24.yaml
@@ -10,5 +10,4 @@ data:
     - nodejs24-full-i18n
     - nodejs24-npm
   labels:
-    - eln
     - c10s

--- a/configs/rhel-pt-ruby-nodejs--nodejs26.yaml
+++ b/configs/rhel-pt-ruby-nodejs--nodejs26.yaml
@@ -1,0 +1,13 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: Node.js 26 runtime
+  description: Node.js 26 (Javascript) runtime and NPM installer for application development
+  maintainer: rhel-pt-ruby-nodejs
+  packages:
+    - nodejs26
+    - nodejs26-devel
+    - nodejs26-full-i18n
+    - nodejs26-npm
+  labels:
+    - eln

--- a/configs/rhel-sst-osci--all.yaml
+++ b/configs/rhel-sst-osci--all.yaml
@@ -6,6 +6,17 @@ data:
   maintainer: rhel-arr-osci
   packages:
     - redhat-internal-test-package
+  package_placeholders:
+    - srpm_name: osci-internal-test-package
+      build_dependencies:
+        - python3-devel
+      rpms:
+        - rpm_name: osci-internal-test-package
+          description: Dummy package for testing and onboarding purposes
+          dependencies:
+            - python3
+        - rpm_name: osci-internal-test-package-noarch
+          description: Architecture-independent files for dummy test package
   labels:
     - eln
     - c10s


### PR DESCRIPTION
- **Add osci-internal-test-package placeholder**
- **Block python3-pytest-socket**
- **Migrate ELN to nodejs26**

https://github.com/fedora-eln/eln/issues/575
