### PR TITLE
Unblock jackson dependencies of dogtag-pki

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -188,12 +188,6 @@ data:
         - texlive-xindy
         # unwanted toolchain
         - mold
-        # dogtag-pki build deps which are vendored in RHEL
-        - fasterxml-oss-parent
-        - jackson-*
-        - jboss-jaxrs-2.0-api
-        - jboss-logging*
-        - pki-resteasy*
         # unwanted weak dependency of ibus-table, ibus-typing-booster
         - python3-simpleaudio
         # unwanted (and rarely used) build dep, pulls in hundreds of Perl deps


### PR DESCRIPTION
dogtag-pki 11.10.1 reverted to system runtime dependencies while also
dropping many of them that were needed only for API v1 support.  This
might end up reverted if bundling (at least for RHEL) is still wanted,
but in the meantime let's not break the IPA workloads.

https://src.fedoraproject.org/rpms/dogtag-pki/c/da92ccd26cf091226ce1f41128c3e39e35be957a
