### PR TITLE
Limit diskimage-builder arches

### DIFF
--- a/configs/epel-stevetraylen--all.yaml
+++ b/configs/epel-stevetraylen--all.yaml
@@ -7,7 +7,6 @@ data:
   packages:
     - alpine
     - cadaver
-    - diskimage-builder
     - edg-gridftp-client
     - edg-mkgridmap
     - fetch-crl
@@ -15,5 +14,12 @@ data:
     - tig
     - uberftp
     - xfig
+  arch_packages:
+    aarch64:
+      - diskimage-builder
+    s390x:
+      - diskimage-builder
+    x86_64:
+      - diskimage-builder
   labels:
     - eln-extras


### PR DESCRIPTION
This depends on libguestfs, but the virt stack is not included on ppc64le.