### PR TITLE
Unblock go-vendor-tools

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -201,8 +201,6 @@ data:
         # golang module packages are obsolete and unwanted
         - golang-*-devel
         - compat-golang-*-devel
-        # needs further pruning before inclusion in RHEL
-        - go-vendor-tools*
         # built with bundled dependencies in RHEL, maintained in ELN branch
         - fence-*
         - pcs


### PR DESCRIPTION
GVT deps have been somewhat minimized, and it almost certainly will be
needed for RHEL 11, so let's unblock it and let packages start showing
their deps on it.

https://github.com/fedora-eln/eln/issues/363
https://gitlab.com/fedora/sigs/go/go-vendor-tools/-/merge_requests/86
