### PR TITLE
ELN Extras: Include ansible-packaging

### DIFF
--- a/configs/epel-gotmax23--all.yaml
+++ b/configs/epel-gotmax23--all.yaml
@@ -8,5 +8,6 @@ data:
     - ansible-collection-ansible-posix
     - ansible-collection-community-crypto
     - ansible-collection-community-general
+    - ansible-packaging
   labels:
     - eln-extras


### PR DESCRIPTION
Required for any package that uses the `%{ansible_collection_url}` macro.