### PR TITLE
Unblock cargo-c

### DIFF
--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -24,6 +24,10 @@ data:
         - qt6-qtwebengine
         # unwanted weak dependency of ibus-table, ibus-typing-booster
         - python3-simpleaudio
+        # unused and conflicting compat version
+        - protobuf3-c
+        - protobuf3-c-compiler
+        - protobuf3-c-devel
         priority: 1
       AppStream:
         baseurl: https://kojipkgs.fedoraproject.org/compose/eln/latest-Fedora-eln/compose/AppStream/$basearch/os/
@@ -211,6 +215,10 @@ data:
         - flatbuffers-*
         - mingw*-python3*
         - xtensor-*
+        # unused and conflicting compat version
+        - protobuf3-c
+        - protobuf3-c-compiler
+        - protobuf3-c-devel
         priority: 4
       Rawhide:
         baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/

--- a/configs/repository-fedora-eln.yaml
+++ b/configs/repository-fedora-eln.yaml
@@ -182,7 +182,6 @@ data:
         - xen-libs
         - xen-devel
         # rust lib crates are unwanted; dependencies must be vendored
-        - cargo-c
         - cargo-rpm-macros
         - rust-srpm-macros
         - rust-*-devel


### PR DESCRIPTION
cargo-c is a build dependency of librsvg2 and rust-gst-plugin-gtk4, and is not designed for vendoring.

Closes: https://github.com/fedora-eln/eln/issues/603
