### PR TITLE
Drop audiotube from Extras

### DIFF
--- a/configs/epel-kde-sig--gear.yaml
+++ b/configs/epel-kde-sig--gear.yaml
@@ -12,7 +12,6 @@ data:
     - artikulate
     - audex
     - audiocd-kio
-    - audiotube
     - baloo-widgets
     - blinken
     - bomber


### PR DESCRIPTION
This requires yt-dlp which was in EPEL 9 at one point but subsequently dropped:

https://lists.fedoraproject.org/archives/list/epel-devel@lists.fedoraproject.org/message/6SWXFQP43JDZOHAMGOCEGBB22OQZO4X7/

See also: https://github.com/fedora-eln/eln/issues/606

/cc @tdawson
