### PR TITLE
cloud: Include cvmutils

### DIFF
--- a/configs/rhel-sst-virtualization-cloud--cloud_azure_cvm.yaml
+++ b/configs/rhel-sst-virtualization-cloud--cloud_azure_cvm.yaml
@@ -1,0 +1,16 @@
+document: feedback-pipeline-workload
+version: 1
+data:
+  name: RHEL on Microsoft Azure Confidential VMs
+  description: Tools to assist running RHEL as a guest on Microsoft Azure CVMs
+  maintainer: rhel-sst-virtualization-cloud
+  packages: []
+  arch_packages:
+    aarch64:
+      - cvm-encrypt-image
+      - cvm-reseal
+    x86_64:
+      - cvm-encrypt-image
+      - cvm-reseal
+  labels:
+    - eln


### PR DESCRIPTION
cvmutils package is being used to encrypt RHEL CVM OS images in Azure.

Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>